### PR TITLE
Fixed #443: File view/edit history doesn't work for temp panel items

### DIFF
--- a/src/path-list.cpp
+++ b/src/path-list.cpp
@@ -13,6 +13,7 @@
 #include "vfs-ftp.h"
 #include "vfs-sftp.h"
 #include "vfs-smb.h"
+#include "vfs-tmp.h"
 #include "unicode_lc.h"
 
 
@@ -277,6 +278,23 @@ bool PathListFSToData(PathList::Data& data, clPtr<FS>* fs, FSPath* path)
 {
     clPtr<StrConfig> cfg = new StrConfig();
     
+	 clPtr<FS> TempFs;
+	 FSPath TempPath;
+	 if ( fs->ptr()->Type() == FS::TMP )
+	 {
+		 // if we are on Temp panel then use base FS
+		 TempFs = ((FSTmp*) fs->ptr())->GetBaseFS();
+		 fs = &TempFs;
+
+		 // path on Temp panel may starts with additional '\'
+		 const char* PathOnTemp = path->GetUtf8();
+		 if ( PathOnTemp && PathOnTemp[0] == '\\' )
+		 {
+			 TempPath.Set( CS_UTF8, ++PathOnTemp );
+			 path = &TempPath;
+		 }
+	 }
+
     if (fs[0]->Type() == FS::SYSTEM)
     {
         cfg->Set("TYPE", "SYSTEM");

--- a/src/vfs/vfs-tmp.h
+++ b/src/vfs/vfs-tmp.h
@@ -113,4 +113,6 @@ public:
 	bool AddNode(FSPath& srcPath, FSNode* fsNode, FSPath& destPath);
 	bool AddNode(FSPath& srcPath, FSPath& destDir);
 	bool baseFsIs(clPtr<FS> fs) { return baseFS == fs; }
+	
+	clPtr<FS> GetBaseFS() { return baseFS; }
 };


### PR DESCRIPTION
Fixed #443 according to the desired behavior.

I have to add FSTmp.GetBaseFS()