### PR TITLE
Additional Unix fix for #443: File view/edit history doesn't work for temp panel items

### DIFF
--- a/src/path-list.cpp
+++ b/src/path-list.cpp
@@ -286,9 +286,9 @@ bool PathListFSToData(PathList::Data& data, clPtr<FS>* fs, FSPath* path)
 		 TempFs = ((FSTmp*) fs->ptr())->GetBaseFS();
 		 fs = &TempFs;
 
-		 // path on Temp panel may starts with additional '\'
+		 // path on Temp panel may starts with additional '\' or '/'
 		 const char* PathOnTemp = path->GetUtf8();
-		 if ( PathOnTemp && PathOnTemp[0] == '\\' )
+		 if ( PathOnTemp && ( PathOnTemp[0] == '\\' || PathOnTemp[0] == '/' ) )
 		 {
 			 TempPath.Set( CS_UTF8, ++PathOnTemp );
 			 path = &TempPath;


### PR DESCRIPTION
This fix is specific to Unix.