### PR TITLE
Fixed #493: Crash in the editor

### DIFF
--- a/src/nceditline.cpp
+++ b/src/nceditline.cpp
@@ -142,5 +142,7 @@ bool clNCEditLine::OnOpenBox()
 
 void clNCEditLine::AddCurrentTextToHistory()
 {
-	AddFieldTextToHistory( m_FieldName, GetText().data() );
+	std::vector<unicode_t> Text = GetText();
+	
+	AddFieldTextToHistory( m_FieldName, Text.data() );
 }


### PR DESCRIPTION
Fixed #493

Needs to be double checked in release (not debug) build before merge.