### PR TITLE
Fixed #514: Added "Process multiple folders" checkbox to create directory dialog

### DIFF
--- a/install-files/share/wcm/lang/ltext.ru
+++ b/install-files/share/wcm/lang/ltext.ru
@@ -694,10 +694,13 @@ txt "Копирование файла"
 id "Create directory"
 txt "Создание папки"
 
-#ncwin.cpp:222
-#ncwin.cpp:900
+#ncdialogs.cpp:746
 id "Create new directory"
 txt "Создание новой папки"
+
+#ncdialogs.cpp:749
+id "Process multiple folders"
+txt "Обработка нескольких папок"
 
 #fileopers.cpp:28
 #fileopers.cpp:32

--- a/src/fileopers.h
+++ b/src/fileopers.h
@@ -79,7 +79,7 @@ public:
 
 ///////////////////////////////// common file opers
 
-bool MkDir( clPtr<FS> f, FSPath& p, NCDialogParent* parent );
+bool MkDir( clPtr<FS> f, FSPath& srcPath, FSPath& destPath, bool processMultipleFolders, NCDialogParent* parent );
 bool DeleteList( clPtr<FS> f, FSPath& p, clPtr<FSList> list, NCDialogParent* parent );
 clPtr<cstrhash<bool, unicode_t> > CopyFiles( clPtr<FS> srcFs, FSPath& srcPath, clPtr<FSList> list, clPtr<FS> destFs, FSPath& destPath, NCDialogParent* parent );
 bool MoveFiles( clPtr<FS> srcFs, FSPath& srcPath, clPtr<FSList> list, clPtr<FS> destFs, FSPath& destPath, NCDialogParent* parent );

--- a/src/ncdialogs.cpp
+++ b/src/ncdialogs.cpp
@@ -734,6 +734,61 @@ public:
 };
 
 
+class clCreateDirDialog : public clInputStrDialogBase
+{
+private:
+	Layout m_Layout;
+	clNCEditLine m_FieldEdit;
+	SButton m_MultipleButton;
+	
+public:
+	clCreateDirDialog( NCDialogParent* Parent, bool IsMultipleFolders, const unicode_t* Str )
+		: clInputStrDialogBase( Parent, utf8_to_unicode( _LT( "Create new directory" ) ).data() )
+		, m_Layout( 2, 9 )
+		, m_FieldEdit( EDIT_FIELD_MAKE_FOLDER, 0, (Win*)this, 0, 100, 7 )
+		, m_MultipleButton( 1, this, utf8_to_unicode( _LT( "Process multiple folders" ) ).data(), 0, IsMultipleFolders )
+	{
+		m_Layout.AddWinAndEnable( &m_FieldEdit, 0, 0, 0, 2 );
+		order.append( &m_FieldEdit );
+		
+		m_Layout.AddWinAndEnable( &m_MultipleButton, 1, 0, 1, 2 );
+		order.append( &m_MultipleButton );
+		
+		AddLayout( &m_Layout );
+		
+		if ( Str )
+		{
+			m_FieldEdit.SetText( Str, true );
+		}
+		
+		m_FieldEdit.SetFocus();
+		SetPosition();
+	}
+	virtual ~clCreateDirDialog() {}
+	
+	bool IsMultipleFolders() const
+	{
+		return m_MultipleButton.IsSet();
+	}
+	
+	virtual std::vector<unicode_t> GetText() const override
+	{
+		return m_FieldEdit.GetText();
+	}
+	
+	virtual std::vector<unicode_t> ShowDialog() override
+	{
+		std::vector<unicode_t> Res = clInputStrDialogBase::ShowDialog();
+		if ( Res.size() > 0 )
+		{
+			m_FieldEdit.AddCurrentTextToHistory();
+		}
+		
+		return Res;
+	}
+};
+
+
 std::vector<unicode_t> InputStringDialog( NCDialogParent* Parent, const unicode_t* Message, const unicode_t* Str )
 {
 	return InputStringDialog( nullptr, Parent, Message, Str );
@@ -749,6 +804,18 @@ std::vector<unicode_t> InputStringDialog( const char* FieldName, NCDialogParent*
 
 	clInputFieldDialog Dlg( FieldName, Parent, Message, Str );
 	return Dlg.ShowDialog();
+}
+
+std::vector<unicode_t> CreateDirDialog( NCDialogParent* Parent, bool* IsMultipleFolders, const unicode_t* Str )
+{
+	clCreateDirDialog Dlg( Parent, *IsMultipleFolders, Str );
+	std::vector<unicode_t> Res = Dlg.ShowDialog();
+	if ( Res.size() > 0 )
+	{
+		*IsMultipleFolders = Dlg.IsMultipleFolders();
+	}
+	
+	return Res;
 }
 
 int uiKillCmdDialog = GetUiID( "KillCmdDialog" );

--- a/src/ncdialogs.h
+++ b/src/ncdialogs.h
@@ -130,6 +130,9 @@ std::vector<unicode_t> InputStringDialog( NCDialogParent* parent, const unicode_
 // input string dialog with history and auto complete support
 std::vector<unicode_t> InputStringDialog( const char* fieldName, NCDialogParent* parent, const unicode_t* message, const unicode_t* str = 0 );
 
+// create directory dialog with history and auto complete support
+std::vector<unicode_t> CreateDirDialog( NCDialogParent* Parent, bool* IsMultipleFolders, const unicode_t* Str = 0 );
+
 
 class CmdHistoryDialog: public NCDialog
 {

--- a/src/plugin/plugin-archive.cpp
+++ b/src/plugin/plugin-archive.cpp
@@ -460,10 +460,10 @@ int FSArch::OpenRead( FSPath& path, int flags, int* err, FSCInfo* info )
 		return -1;
 	}
 
-	// seek to the entry
 	struct archive_entry* entry = archive_entry_new2( Arch );
 	int Res;
 
+	// seek to the entry
 	while ( ( Res = archive_read_next_header2( Arch, entry ) ) == ARCHIVE_OK )
 	{
 		int64_t EntryOffset = archive_read_header_position( Arch );
@@ -478,6 +478,8 @@ int FSArch::OpenRead( FSPath& path, int flags, int* err, FSCInfo* info )
 
 	if ( Res != ARCHIVE_OK )
 	{
+		ArchClose( Arch );
+		
 		dbg_printf( "Couldn't read archive entry: %s\n", archive_error_string( Arch ) );
 		FS::SetError( err, FSARCH_ERROR_FILE_NOT_FOUND );
 		return -1;

--- a/src/vfs/vfspath.cpp
+++ b/src/vfs/vfspath.cpp
@@ -212,6 +212,19 @@ bool FSPath::Equals(FSPath* that)
 	return true;
 }
 
+int FSPath::GetFirstUnmatchedItem( FSPath& otherPath )
+{
+	for ( int i = 0; i < otherPath.Count(); i++ )
+	{
+		if ( i >= Count() || GetItem( i )->Cmp( *otherPath.GetItem( i ) ) )
+		{
+			return i;
+		}
+	}
+	
+	return -1;
+}
+
 FSPath::~FSPath() {}
 
 

--- a/src/vfs/vfspath.h
+++ b/src/vfs/vfspath.h
@@ -224,6 +224,7 @@ public:
 	const char* GetUtf8( char delimiter = DIR_SPLITTER ) { return ( const char* ) GetString( CS_UTF8, delimiter ); }
 
 	bool Equals(FSPath* that);
+	int GetFirstUnmatchedItem( FSPath& otherPath );
 
 	void dbg_printf(const char* label)
 	{


### PR DESCRIPTION
Added possibility to create multiple sub-folders at once. For example:
* specifying **dir1/dir2/dir3** will create the sub-directories under current folder
* but adding slash at the beginning **/dir1/dir2/dir3** will create them under root folder of current volume