### PR TITLE
fixed from PVS-Studio:

### DIFF
--- a/src/help.cpp
+++ b/src/help.cpp
@@ -1026,10 +1026,6 @@ begin:
 					NextChar();
 					continue;
 			}
-
-			word.append( cchar );
-			NextChar();
-			continue;
 		}
 
 
@@ -1195,8 +1191,6 @@ clPtr<HelpNode> HelpParzer::ParzeTable()
 				pTable->Append( Parze() );
 				continue;
 		};
-
-		NextToken();
 	}
 
 	return ret;

--- a/src/wcm-config.cpp
+++ b/src/wcm-config.cpp
@@ -706,12 +706,9 @@ bool RegReadBin( const char* sect, const char* what, const void* data, int size 
 		return false;
 	}
 
-	if ( lResult == ERROR_SUCCESS )
-	{
-		ASSERT( dwType == REG_BINARY );
-		lResult = RegQueryValueEx( hsect, ( LPTSTR )what, NULL, &dwType,
-		                           ( LPBYTE )data, &dwCount );
-	}
+	ASSERT( dwType == REG_BINARY );
+	lResult = RegQueryValueEx( hsect, ( LPTSTR )what, NULL, &dwType,
+	                           ( LPBYTE )data, &dwCount );
 
 	RegCloseKey( hsect );
 	return ( lResult == ERROR_SUCCESS );


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings: 
[V779](https://www.viva64.com/en/w/v779/) Unreachable code detected. It is possible that an error is present.
[V547](https://www.viva64.com/en/w/v547/) Expression 'lResult == 0L' is always true.
