### PR TITLE
LANG environment variable can be UTF-8 and UTF8.

### DIFF
--- a/src/wal/wal_sys_api.cpp
+++ b/src/wal/wal_sys_api.cpp
@@ -338,6 +338,7 @@ namespace wal
 	static LacaleCharsetAlias csAliasTable[] =
 	{
 		{"UTF-8",   CS_UTF8},
+		{"UTF8",    CS_UTF8},
 		{"CP1251",  CS_WIN1251},
 		{"CP866",   CS_CP866},
 		{"KOI8-R",  CS_KOI8R},


### PR DESCRIPTION
LANG environment variable can be UTF-8 and UTF8. Added UTF8 name to alias table.