### PR TITLE
Add JS syntax highlight configuration

### DIFF
--- a/install-files/share/wcm/shl/config.cfg
+++ b/install-files/share/wcm/shl/config.cfg
@@ -1,5 +1,6 @@
 #for wcm ver >= 0.15.10
 syntax "C" 	{ cfg = "c.shl"; };
+syntax "JS" 	{ cfg = "js.shl"; };
 syntax "C++" 	{  cfg = "cpp.shl"; };
 syntax "sh" 	{  cfg = "sh.shl"; };
 syntax "perl" 	{  cfg = "perl.shl"; };
@@ -32,6 +33,7 @@ rule mask ("*\\shl\\config.cfg","*/shl/config.cfg")	"wcm-shl-main";
 rule mask ("*\\shl\\*.shl","*/shl/*.shl")		"wcm-shl";
 # Comment the next line to enable MATLAB/Octave syntax support
 rule mask ("*.c","*.cc","*.cpp","*.h","*.hpp","*.C","*.m")	"C++";
+rule mask ("*.js","*.mjs","*.cjs","*.json")	"JS";
 # Uncomment the next line to enable MATLAB/Octave syntax support
 #rule mask ("*.c","*.cc","*.cpp","*.h","*.hpp","*.C")	"C++";
 rule mask ("*.pl")	"perl";

--- a/install-files/share/wcm/shl/js.shl
+++ b/install-files/share/wcm/shl/js.shl
@@ -30,12 +30,13 @@ state newline default {
 	rule	<[$(a)$(d)_]+>	{ 
 		state = default;  
 		words (KEYWORD) = {
-			'break', 'case', 'catch', 'class', 'const', 'constructor', 'continue', 'do', 'else', 'export', 'for',
-			'from', 'function', 'goto', 'if', 'import', 'new', 'prototype', 'return', 'switch', 'throw', 'try',
-			'var', 'while'
+			'break', 'case', 'catch', 'class', 'const', 'constructor',
+			'continue', 'delete', 'do', 'else', 'export', 'for', 'from',
+			'function', 'goto', 'if', 'import', 'new', 'prototype',
+			'return', 'switch', 'throw', 'try','var', 'while'
 		};
 		words (NUM) = {
-			'NaN', 'infinity', 'undefined', 'null'
+			'NaN', 'infinity', 'undefined', 'null', 'true', 'false'
 		};
 	};
 	rule	<[$(a)$(d)_]+\:>	{ 

--- a/install-files/share/wcm/shl/js.shl
+++ b/install-files/share/wcm/shl/js.shl
@@ -1,0 +1,102 @@
+start newline;
+
+chars a [a-zA-Z];
+chars d [0-9];
+chars s [\t\ ];
+
+state newline default {
+	rule	<\n>	{ state = newline; };
+	rule	</\*>	{ state=comment_1; color=COMMENT; };
+	rule	<//>	{ state=comment_2; color=COMMENT; };
+	rule	<$(s)+> ;
+	rule	<\">	{ state=string; color=STRING; };
+	rule	<\'>	{ state=string2; color=STRING; };
+	rule	<\`>	{ state=fstring; color=STRING; };
+
+	
+	rule	<0x[0-9a-fA-F]+>	{ state = default; color = NUM; };
+	rule	<$(d)+[\.]*$(d)*[eE]*$(d)*>	{ state = default; color = NUM; };
+	
+	rule <\&\&> { state = default;  color = OPER; };
+	rule <\|\|> { state = default;  color = OPER; };
+
+	rule <[,.=\+\-\*\/\%\^\&|]> { state = default;  color = OPER; };
+	
+	rule <[{}():;]> { state = default;  color = KEYWORD; };
+
+	rule <[{}():;]> { state = default;  color = KEYWORD; };
+
+
+	rule	<[$(a)$(d)_]+>	{ 
+		state = default;  
+		words (KEYWORD) = {
+			'break', 'case', 'catch', 'class', 'const', 'constructor', 'continue', 'do', 'else', 'export', 'for',
+			'from', 'function', 'goto', 'if', 'import', 'new', 'prototype', 'return', 'switch', 'throw', 'try',
+			'var', 'while'
+		};
+		words (NUM) = {
+			'NaN', 'infinity', 'undefined', 'null'
+		};
+	};
+	rule	<[$(a)$(d)_]+\:>	{ 
+		state = default; color = NUM;
+	};
+	
+	rule 	<...> { color = KEYWORD; };
+};
+
+state newline {;
+	rule	<\#>	 {state=pre;	color=PRE; };
+	rule 	<[^$(s)]> { state=default; };
+};
+	
+state comment_1	{
+	color=COMMENT;
+	rule	<\*/>	{ state=default; };
+};
+	
+state comment_2	{
+	color=COMMENT;
+	rule	<\\\n>;
+	rule	<\n>	{state=newline;};
+};
+	
+state pre {
+	color = PRE;
+	rule	</\*>	{ state=comment_1; color=COMMENT; };
+	rule	<//>	{ state=comment_2; color=COMMENT; };
+	rule	<\\\n>;
+	rule	<\n>	{state=newline; };
+};
+	
+state string {
+	color = STRING;
+	rule	<\\\\>;
+	rule	<\\\">;
+	rule	<\">	{state=default;};
+};
+
+state string2 {
+	color = STRING;
+	rule	<\\\\>;
+	rule	<\\\'>;
+	rule	<\'>	{state=default;};
+};
+
+state fstring {
+	color = STRING;
+	rule	<\\\\>;
+	rule	<\\\`>;
+	rule	<\`>	{state=default;};
+
+	rule	<\$\{> { state=field; color=STRING; };
+
+};
+
+state field {
+	color = STRING;
+	rule	<\{>;
+
+	rule	<}> { state=fstring; color=STRING; };
+
+};


### PR DESCRIPTION
This is a quick implementation of JS highlighting (ES6)

There are a few additional things I'd like to control the color of...

- I'd like to match the names preceding a colon to be like 'object field' color...

``` 
{ 
   objectField : data
   ['another field'] : data,
  'quoted field' : data,
}
```

- formatted strings

```
    `some ${content} ${ fancy_expression(()=>{ /*code*/} ) }  ...`
```

which `${` within a formatted string begins a phrase thata returns default state, until `}` that matches the open one that restores it back to string color...


